### PR TITLE
Update fbgemm version

### DIFF
--- a/fp8_requirements.txt
+++ b/fp8_requirements.txt
@@ -28,4 +28,4 @@ ufmt==2.7.0
 usort==1.0.8
 uvicorn
 zmq
-fbgemm-gpu==0.8.0rc4
+fbgemm-gpu==0.8.0


### PR DESCRIPTION
Update fbgemm version to stable 0.8.0. Previous rc4 version was accidentally deprecated in https://pypi.org/project/fbgemm-gpu/#history .